### PR TITLE
Adds support for saving files from AWS SM

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM buildkite/plugin-tester
+
+RUN apk update && \
+ apk upgrade && \
+ apk add jq

--- a/README.md
+++ b/README.md
@@ -26,6 +26,11 @@ steps:
         env:
           MY_SECRET: my-secret-id
           MY_OTHER_SECRET: my-other-secret-id
+        file:
+          - path: 'save-my-secret-here'
+            secret-id: 'my-secret-file-id'
+          - path: 'save-my-other-secret-here'
+            secret-id: 'my-other-secret-file-id'
 ```
 
 ## For Secrets in Another Account
@@ -39,6 +44,9 @@ steps:
       seek-oss/aws-sm#v0.0.2:
         env:
           SECRET_FROM_OTHER_ACCOUNT: 'arn:aws:secretsmanager:ap-southeast-2:1234567:secret:my-global-secret'
+        file:
+          - path: 'save-my-other-secret-here'
+            secret-id: 'arn:aws:secretsmanager:ap-southeast-2:1234567:secret:my-global-file-secret'
 ```
 
 # Tests

--- a/README.md
+++ b/README.md
@@ -11,6 +11,19 @@ Unlike [AWS Systems Manager (AWS SSM) Parameter Store](https://aws.amazon.com/sy
 
 See [AWS Setup](./AWSSETUP.md) for instructions on setting up the provider AWS account, and the build agent permissions.
 
+# Supported Secrets
+
+This plugin supports both `SecretString` and `SecretBinary` [AWS SM secret types](https://docs.aws.amazon.com/secretsmanager/latest/apireference/API_GetSecretValue.html).
+
+## SecretString
+
+A AWS SM secret string may be plaintext or key/value. If you create a key/value secret, then the JSON will be returned. This plugin does not yet support expanding the plugin for you, but `jq` can be used to pull JSON values out.
+
+`SecretString`s can be exposed in an environment variable (`env`) or saved to a file.
+
+## SecretBinary
+
+Binary secrets can be saved to a file. They cannot be used with `env` (as they contain binary data).
 
 # Example
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,8 @@
 version: '2'
 services:
   tests:
-    image: buildkite/plugin-tester
+    build:
+      context: .
     volumes:
       - ".:/plugin:ro"
   lint:

--- a/hooks/environment
+++ b/hooks/environment
@@ -26,6 +26,6 @@ while IFS='=' read -r name _ ; do
     pathVar="${itemVar}_PATH"
     path=$(strip_quotes "${!pathVar}")
     echo "--- :aws::key: Reading ${secretId} from AWS SM into file ${path}"
-    get_secret_value "${secretId}" > "${path}"
+    get_secret_value "${secretId}" 'allow-binary' > "${path}"
   fi
 done < <(env | sort)

--- a/hooks/environment
+++ b/hooks/environment
@@ -17,15 +17,3 @@ while IFS='=' read -r name _ ; do
     export "${exportName}=${value}"
   fi
 done < <(env | sort)
-
-# parse file items
-while IFS='=' read -r name _ ; do
-  if [[ $name =~ ^(BUILDKITE_PLUGIN_AWS_SM_FILE_[0-9]+_SECRET_ID)$ ]] ; then
-    itemVar=$(echo "${name}" | sed 's/_SECRET_ID$//')
-    secretId=$(strip_quotes "${!name}")
-    pathVar="${itemVar}_PATH"
-    path=$(strip_quotes "${!pathVar}")
-    echo "--- :aws::key: Reading ${secretId} from AWS SM into file ${path}"
-    get_secret_value "${secretId}" 'allow-binary' > "${path}"
-  fi
-done < <(env | sort)

--- a/hooks/environment
+++ b/hooks/environment
@@ -20,11 +20,11 @@ done < <(env | sort)
 
 # parse file items
 while IFS='=' read -r name _ ; do
-  if [[ $name =~ ^(BUILDKITE_PLUGIN_AWS_SM_FILE_[0-9]+)$ ]] ; then
-    pathVar="${name}_PATH"
-    secretIdVar="${name}_SECRET_ID"
+  if [[ $name =~ ^(BUILDKITE_PLUGIN_AWS_SM_FILE_[0-9]+_SECRET_ID)$ ]] ; then
+    itemVar=$(echo "${name}" | sed 's/_SECRET_ID$//')
+    secretId=$(strip_quotes "${!name}")
+    pathVar="${itemVar}_PATH"
     path=$(strip_quotes "${!pathVar}")
-    secretId=$(strip_quotes "${!secretIdVar}")
     echo "--- :aws::key: Reading ${secretId} from AWS SM into file ${path}"
     get_secret_value "${secretId}" > "${path}"
   fi

--- a/hooks/environment
+++ b/hooks/environment
@@ -2,39 +2,30 @@
 
 set -euo pipefail
 
-# AWS SM is only in very recent AWS CLI versions, and isn't on Amazon Linux 2 AMIs (as of July 2018)
-docker pull infrastructureascode/aws-cli
+DIR="$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)"
 
-function get_secret_value() {
-  local secretId="$1"
-  docker run \
-    --rm \
-    -v ~/.aws:/root/.aws \
-    -e 'AWS_ACCESS_KEY_ID' \
-    -e 'AWS_SECRET_ACCESS_KEY' \
-    -e 'AWS_DEFAULT_REGION' \
-    -e 'AWS_REGION' \
-    -e 'AWS_SECURITY_TOKEN' \
-    -e 'AWS_SESSION_TOKEN' \
-    infrastructureascode/aws-cli \
-    aws secretsmanager get-secret-value \
-      --secret-id "${secretId}" \
-      --version-stage AWSCURRENT \
-      --output text \
-      --query 'SecretString'
-}
-
-function strip_quotes() {
-  echo "${1}" | sed "s/^[ \t]*//g;s/[ \t]*$//g;s/[\"']//g"
-}
+# shellcheck source=lib/shared.bash
+. "$DIR/../lib/shared.bash"
 
 # parse env items
 while IFS='=' read -r name _ ; do
   if [[ $name =~ ^(BUILDKITE_PLUGIN_AWS_SM_ENV_) ]] ; then
     exportName=$(echo "${name}" | sed 's/^BUILDKITE_PLUGIN_AWS_SM_ENV_//')
     secretId=$(strip_quotes "${!name}")
-    echo "--- :aws::key: Reading ${secretId} from AWS SM into ${exportName}"
+    echo "--- :aws::key: Reading ${secretId} from AWS SM into environment variable ${exportName}"
     value=$(get_secret_value "${secretId}")
     export "${exportName}=${value}"
+  fi
+done < <(env | sort)
+
+# parse file items
+while IFS='=' read -r name _ ; do
+  if [[ $name =~ ^(BUILDKITE_PLUGIN_AWS_SM_FILE_[0-9]+)$ ]] ; then
+    pathVar="${name}_PATH"
+    secretIdVar="${name}_SECRET_ID"
+    path=$(strip_quotes "${!pathVar}")
+    secretId=$(strip_quotes "${!secretIdVar}")
+    echo "--- :aws::key: Reading ${secretId} from AWS SM into file ${path}"
+    get_secret_value "${secretId}" > "${path}"
   fi
 done < <(env | sort)

--- a/hooks/post-checkout
+++ b/hooks/post-checkout
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+DIR="$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)"
+
+# shellcheck source=lib/shared.bash
+. "$DIR/../lib/shared.bash"
+
+# parse file items
+while IFS='=' read -r name _ ; do
+  if [[ $name =~ ^(BUILDKITE_PLUGIN_AWS_SM_FILE_[0-9]+_SECRET_ID)$ ]] ; then
+    itemVar=$(echo "${name}" | sed 's/_SECRET_ID$//')
+    secretId=$(strip_quotes "${!name}")
+    pathVar="${itemVar}_PATH"
+    path=$(strip_quotes "${!pathVar}")
+    echo "--- :aws::key: Reading ${secretId} from AWS SM into file ${path}"
+    get_secret_value "${secretId}" 'allow-binary' > "${path}"
+  fi
+done < <(env | sort)

--- a/lib/shared.bash
+++ b/lib/shared.bash
@@ -11,7 +11,7 @@ function get_secret_value() {
   local secretId="$1"
 
   # Extract the secret string and secret binary
-  local secrets=$(docker run \
+  read secrets < <(docker run \
     --rm \
     -v ~/.aws:/root/.aws \
     -e 'AWS_ACCESS_KEY_ID' \
@@ -28,7 +28,7 @@ function get_secret_value() {
       --query '{SecretString: SecretString, SecretBinary: SecretBinary}')
 
   # if the secret binary field has a value, assume it's a binary
-  local secretBinary=$(echo "${secrets}" | jq -r '.SecretBinary | select(. != null)')
+  read secretBinary < <(echo "${secrets}" | jq -r '.SecretBinary | select(. != null)')
   if [[ -n "${secretBinary}" ]]; then
     echo "${secretBinary}" | base64 --decode
     return

--- a/lib/shared.bash
+++ b/lib/shared.bash
@@ -30,7 +30,7 @@ function get_secret_value() {
   # if the secret binary field has a value, assume it's a binary
   local secretBinary=$(echo "${secrets}" | jq -r '.SecretBinary | select(. != null)')
   if [[ -n "${secretBinary}" ]]; then
-    echo "${secretBinary}"
+    echo "${secretBinary}" | base64 -d
     return
   fi
 

--- a/lib/shared.bash
+++ b/lib/shared.bash
@@ -28,9 +28,9 @@ function get_secret_value() {
       --query '{SecretString: SecretString, SecretBinary: SecretBinary}')
 
   # if the secret binary field has a value, assume it's a binary
-  read secretBinary < <(echo "${secrets}" | jq -r '.SecretBinary | select(. != null)')
+  local secretBinary=$(echo "${secrets}" | jq -r '.SecretBinary | select(. != null)')
   if [[ -n "${secretBinary}" ]]; then
-    echo "${secretBinary}" | base64 --decode
+    echo "${secretBinary}"
     return
   fi
 

--- a/lib/shared.bash
+++ b/lib/shared.bash
@@ -12,7 +12,7 @@ function get_secret_value() {
   local allowBinary="${2-}"
 
   # Extract the secret string and secret binary
-  read secrets < <(docker run \
+  local secrets=$(docker run \
     --rm \
     -v ~/.aws:/root/.aws \
     -e 'AWS_ACCESS_KEY_ID' \

--- a/lib/shared.bash
+++ b/lib/shared.bash
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+function strip_quotes() {
+  echo "${1}" | sed "s/^[ \t]*//g;s/[ \t]*$//g;s/[\"']//g"
+}
+
+# AWS SM is only in very recent AWS CLI versions, and isn't on Amazon Linux 2 AMIs (as of July 2018)
+docker pull infrastructureascode/aws-cli
+
+function get_secret_value() {
+  local secretId="$1"
+
+  # Extract the secret string and secret binary
+  local secrets=$(docker run \
+    --rm \
+    -v ~/.aws:/root/.aws \
+    -e 'AWS_ACCESS_KEY_ID' \
+    -e 'AWS_SECRET_ACCESS_KEY' \
+    -e 'AWS_DEFAULT_REGION' \
+    -e 'AWS_REGION' \
+    -e 'AWS_SECURITY_TOKEN' \
+    -e 'AWS_SESSION_TOKEN' \
+    infrastructureascode/aws-cli \
+    aws secretsmanager get-secret-value \
+      --secret-id "${secretId}" \
+      --version-stage AWSCURRENT \
+      --output json \
+      --query '{SecretString: SecretString, SecretBinary: SecretBinary}')
+
+  # if the secret binary field has a value, assume it's a binary
+  local secretBinary=$(echo "${secrets}" | jq -r '.SecretBinary | select(. != null)')
+  if [[ -n "${secretBinary}" ]]; then
+    echo "${secretBinary}" | base64 --decode
+    return
+  fi
+
+  # assume it's a string
+  echo "${secrets}" | jq -r '.SecretString'
+}

--- a/plugin.yml
+++ b/plugin.yml
@@ -1,9 +1,13 @@
 name: aws-sm
 description: Read secrets from AWS Secrets Manager
 author: https://github.com/seek-oss
-requirements: []
+requirements:
+  - docker
+  - jq
 configuration:
   properties:
     env:
       type: object
+    file:
+      type: array
   required: []

--- a/tests/environment.bats
+++ b/tests/environment.bats
@@ -4,35 +4,39 @@ load "$BATS_PATH/load.bash"
 
 environment_hook="$PWD/hooks/environment"
 
-function stub_secret_plan() {
-  local secretId="${1}"
-  local secretJson="${2}"
-  echo "run --rm -v ~/.aws:/root/.aws -e 'AWS_ACCESS_KEY_ID' -e 'AWS_SECRET_ACCESS_KEY' -e 'AWS_DEFAULT_REGION' -e 'AWS_REGION' -e 'AWS_SECURITY_TOKEN' -e 'AWS_SESSION_TOKEN' infrastructureascode/aws-cli aws secretsmanager get-secret-value --secret-id ${secretId} --version-stage AWSCURRENT --output json --query '{SecretString: SecretString, SecretBinary: SecretBinary}' : echo ${secretJson}"
+export SECRET_ID1='secret1'
+export SECRET_VALUE1='{"SecretString":"pretty-secret","SecretBinary":null}'
+export SECRET_ID2='secret2'
+export SECRET_VALUE2='{"SecretString":"topsecret","SecretBinary":null}'
+export SECRET_ID3='secret3'
+export SECRET_VALUE3='{"SecretString":null,"SecretBinary":"base64-secret"}'
+
+# this is used instead of bats mock, as many of the arguments aren't important
+# to assert...
+function docker() {
+  if [[ "$1" != "run" ]]; then
+    echo "ran docker $1"
+    return
+  fi
+
+  # echo the secret value based on its id
+  read secretNo < <(echo "$@" | grep -o 'secret[0-9]' | grep -o '[0-9]')
+  local secretVar="SECRET_VALUE${secretNo}"
+  echo "${!secretVar}"
 }
 
 @test "Fetches values from AWS SM into env" {
-  export BUILDKITE_PLUGIN_AWS_SM_ENV_TARGET1='SECRET_ID1'
-  export BUILDKITE_PLUGIN_AWS_SM_ENV_TARGET2="'SECRET_ID2'"
+  export BUILDKITE_PLUGIN_AWS_SM_ENV_TARGET1="${SECRET_ID1}"
+  export BUILDKITE_PLUGIN_AWS_SM_ENV_TARGET2="'${SECRET_ID2}'"
 
-  local secretValue1='{SecretString:"secret"}'
-  local secretValue2='{SecretString:"secret"}'
-
-  # the stub plan has to be declared at the same time (e.g. can't stub docker multiple times)
-  stub docker \
-    "pull infrastructureascode/aws-cli : echo ran docker pull" \
-    stub_secret_plan 'SECRET_ID1' "${secretValue1}" \
-    stub_secret_plan 'SECRET_ID2' "${secretValue2}"
-
-  stub jq \
-    "-r '.SecretBinary | select(. != null)' : echo ''" \
-    "-r '.SecretString' : echo 'secret'"
+  export -f docker
 
   run "${environment_hook}"
 
-  assert_output --partial "Reading SECRET_ID1 from AWS SM into environment variable TARGET1"
-  assert_output --partial "Reading SECRET_ID2 from AWS SM into environment variable TARGET2"
-  assert_output --partial "ran docker pull"
   assert_success
+  assert_output --partial "Reading ${SECRET_ID1} from AWS SM into environment variable TARGET1"
+  assert_output --partial "Reading ${SECRET_ID2} from AWS SM into environment variable TARGET2"
+  assert_output --partial "ran docker pull"
 
   unset BUILDKITE_PLUGIN_AWS_SM_ENV_TARGET1
   unset BUILDKITE_PLUGIN_AWS_SM_ENV_TARGET2
@@ -43,31 +47,17 @@ function stub_secret_plan() {
   mkdir -p "${test_out_dir}"
   export BUILDKITE_PLUGIN_AWS_SM_FILE_0=''
   export BUILDKITE_PLUGIN_AWS_SM_FILE_0_PATH="${test_out_dir}/path1"
-  export BUILDKITE_PLUGIN_AWS_SM_FILE_0_SECRET_ID='SECRET_ID1'
+  export BUILDKITE_PLUGIN_AWS_SM_FILE_0_SECRET_ID="${SECRET_ID1}"
   export BUILDKITE_PLUGIN_AWS_SM_FILE_1=''
   export BUILDKITE_PLUGIN_AWS_SM_FILE_1_PATH="'${test_out_dir}/path2'"
-  export BUILDKITE_PLUGIN_AWS_SM_FILE_1_SECRET_ID="'SECRET_ID2'"
+  export BUILDKITE_PLUGIN_AWS_SM_FILE_1_SECRET_ID="'${SECRET_ID3}'"
 
-  local secretValue1='{SecretBinary:"secretbase64"}'
-  local secretValue2='{SecretString:"secret"}'
-
-  # the stub plan has to be declared at the same time (e.g. can't stub docker multiple times)
-  stub docker \
-    "pull infrastructureascode/aws-cli : echo ran docker pull" \
-    stub_secret_plan 'SECRET_ID1' "${secretValue1}" \
-    stub_secret_plan 'SECRET_ID2' "${secretValue2}"
-
-  stub jq \
-    "-r '.SecretBinary | select(. != null)' : echo ''" \
-    "-r '.SecretString' : echo 'secret'"
-
-  stub base64 \
-    "--decode : echo 'final secret'"
+  export -f docker
 
   run "${environment_hook}"
 
-  assert_output --partial "Reading SECRET_ID1 from AWS SM into file ${test_out_dir}/path1"
-  assert_output --partial "Reading SECRET_ID2 from AWS SM into file ${test_out_dir}/path2"
+  assert_output --partial "Reading ${SECRET_ID1} from AWS SM into file ${test_out_dir}/path1"
+  assert_output --partial "Reading ${SECRET_ID3} from AWS SM into file ${test_out_dir}/path2"
   assert_output --partial "ran docker pull"
   assert_success
 

--- a/tests/environment.bats
+++ b/tests/environment.bats
@@ -8,8 +8,12 @@ export SECRET_ID1='secret1'
 export SECRET_VALUE1='{"SecretString":"pretty-secret","SecretBinary":null}'
 export SECRET_ID2='secret2'
 export SECRET_VALUE2='{"SecretString":"topsecret","SecretBinary":null}'
+# hello
 export SECRET_ID3='secret3'
-export SECRET_VALUE3='{"SecretString":null,"SecretBinary":"base64-secret"}'
+export SECRET_VALUE3='{"SecretString":null,"SecretBinary":"aGVsbG8="}'
+# world
+export SECRET_ID4='secret4'
+export SECRET_VALUE4='{"SecretString":null,"SecretBinary":"d29ybGQ="}'
 
 # this is used instead of bats mock, as many of the arguments aren't important
 # to assert...
@@ -45,26 +49,30 @@ function docker() {
 @test "Fetches values from AWS SM into file" {
   local test_out_dir="/tmp/aws-sm"
   mkdir -p "${test_out_dir}"
-  export BUILDKITE_PLUGIN_AWS_SM_FILE_0=''
-  export BUILDKITE_PLUGIN_AWS_SM_FILE_0_PATH="${test_out_dir}/path1"
+  local path1="${test_out_dir}/path1"
+  local path2="${test_out_dir}/path2"
+  export BUILDKITE_PLUGIN_AWS_SM_FILE_0_PATH="${path1}"
   export BUILDKITE_PLUGIN_AWS_SM_FILE_0_SECRET_ID="${SECRET_ID1}"
-  export BUILDKITE_PLUGIN_AWS_SM_FILE_1=''
-  export BUILDKITE_PLUGIN_AWS_SM_FILE_1_PATH="'${test_out_dir}/path2'"
+  export BUILDKITE_PLUGIN_AWS_SM_FILE_1_PATH="'${path2}'"
   export BUILDKITE_PLUGIN_AWS_SM_FILE_1_SECRET_ID="'${SECRET_ID3}'"
 
   export -f docker
 
   run "${environment_hook}"
 
-  assert_output --partial "Reading ${SECRET_ID1} from AWS SM into file ${test_out_dir}/path1"
-  assert_output --partial "Reading ${SECRET_ID3} from AWS SM into file ${test_out_dir}/path2"
+  assert_output --partial "Reading ${SECRET_ID1} from AWS SM into file ${path1}"
+  assert_output --partial "Reading ${SECRET_ID3} from AWS SM into file ${path2}"
   assert_output --partial "ran docker pull"
   assert_success
 
-  unset BUILDKITE_PLUGIN_AWS_SM_FILE_0
+  local actualPath1=$(cat "${path1}")
+  local actualPath2=$(cat "${path2}")
+
+  [[ "${actualPath1}" != "pretty-secret" ]] && fail "Expected contents to be saved to file"
+  [[ "${actualPath2}" != "hello" ]] && fail "Expected contents to be saved to file"
+
   unset BUILDKITE_PLUGIN_AWS_SM_FILE_0_PATH
   unset BUILDKITE_PLUGIN_AWS_SM_FILE_0_SECRET_ID
-  unset BUILDKITE_PLUGIN_AWS_SM_FILE_1
   unset BUILDKITE_PLUGIN_AWS_SM_FILE_1_PATH
   unset BUILDKITE_PLUGIN_AWS_SM_FILE_1_SECRET_ID
 }

--- a/tests/environment.bats
+++ b/tests/environment.bats
@@ -46,6 +46,21 @@ function docker() {
   unset BUILDKITE_PLUGIN_AWS_SM_ENV_TARGET2
 }
 
+@test "Fails if attempting to read binary secret into env var" {
+  export BUILDKITE_PLUGIN_AWS_SM_ENV_TARGET1="${SECRET_ID4}"
+
+  export -f docker
+
+  run "${environment_hook}"
+
+  assert_failure
+  assert_output --partial "Reading ${SECRET_ID4} from AWS SM into environment variable TARGET1"
+  assert_output --partial "Binary encoded secret cannot be used in this way"
+  assert_output --partial "ran docker pull"
+
+  unset BUILDKITE_PLUGIN_AWS_SM_ENV_TARGET1
+}
+
 @test "Fetches values from AWS SM into file" {
   local test_out_dir="/tmp/aws-sm"
   mkdir -p "${test_out_dir}"

--- a/tests/environment.bats
+++ b/tests/environment.bats
@@ -8,19 +8,58 @@ docker() {
   echo "ran docker $1"
 }
 
-@test "Fetches values from AWS SM" {
+jq() {
+  echo "ran jq"
+}
+
+base64() {
+  echo "ran base64"
+}
+
+@test "Fetches values from AWS SM into env" {
   export BUILDKITE_PLUGIN_AWS_SM_ENV_TARGET1='SECRET_ID1'
   export BUILDKITE_PLUGIN_AWS_SM_ENV_TARGET2="'SECRET_ID2'"
 
   export -f docker
+  export -f jq
+  export -f base64
 
   run "${environment_hook}"
 
-  assert_output --partial "Reading SECRET_ID1 from AWS SM into TARGET1"
-  assert_output --partial "Reading SECRET_ID2 from AWS SM into TARGET2"
+  assert_output --partial "Reading SECRET_ID1 from AWS SM into environment variable TARGET1"
+  assert_output --partial "Reading SECRET_ID2 from AWS SM into environment variable TARGET2"
   assert_output --partial "ran docker pull"
   assert_success
 
   unset BUILDKITE_PLUGIN_AWS_SM_ENV_TARGET1
   unset BUILDKITE_PLUGIN_AWS_SM_ENV_TARGET2
+}
+
+@test "Fetches values from AWS SM into file" {
+  local test_out_dir="/tmp/aws-sm"
+  mkdir -p "${test_out_dir}"
+  export BUILDKITE_PLUGIN_AWS_SM_FILE_0=''
+  export BUILDKITE_PLUGIN_AWS_SM_FILE_0_PATH="${test_out_dir}/path1"
+  export BUILDKITE_PLUGIN_AWS_SM_FILE_0_SECRET_ID='SECRET_ID1'
+  export BUILDKITE_PLUGIN_AWS_SM_FILE_1=''
+  export BUILDKITE_PLUGIN_AWS_SM_FILE_1_PATH="'${test_out_dir}/path2'"
+  export BUILDKITE_PLUGIN_AWS_SM_FILE_1_SECRET_ID="'SECRET_ID2'"
+
+  export -f docker
+  export -f jq
+  export -f base64
+
+  run "${environment_hook}"
+
+  assert_output --partial "Reading SECRET_ID1 from AWS SM into file ${test_out_dir}/path1"
+  assert_output --partial "Reading SECRET_ID2 from AWS SM into file ${test_out_dir}/path2"
+  assert_output --partial "ran docker pull"
+  assert_success
+
+  unset BUILDKITE_PLUGIN_AWS_SM_FILE_0
+  unset BUILDKITE_PLUGIN_AWS_SM_FILE_0_PATH
+  unset BUILDKITE_PLUGIN_AWS_SM_FILE_0_SECRET_ID
+  unset BUILDKITE_PLUGIN_AWS_SM_FILE_1
+  unset BUILDKITE_PLUGIN_AWS_SM_FILE_1_PATH
+  unset BUILDKITE_PLUGIN_AWS_SM_FILE_1_SECRET_ID
 }

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -3,6 +3,7 @@
 load "$BATS_PATH/load.bash"
 
 environment_hook="$PWD/hooks/environment"
+post_checkout_hook="$PWD/hooks/post-checkout"
 
 export SECRET_ID1='secret1'
 export SECRET_VALUE1='{"SecretString":"pretty-secret","SecretBinary":null}'
@@ -73,7 +74,7 @@ function docker() {
 
   export -f docker
 
-  run "${environment_hook}"
+  run "${post_checkout_hook}"
 
   assert_output --partial "Reading ${SECRET_ID1} from AWS SM into file ${path1}"
   assert_output --partial "Reading ${SECRET_ID3} from AWS SM into file ${path2}"


### PR DESCRIPTION
This adds support for a `file` block to save a secret from AWS SM into a `path`. This automatically decodes the `SecretBinary` if provided, otherwise falls back on the `SecretString`

This still runs at `environment` hook time, but we may want to add the option of working with files at `post-checkout` (so they don't get `git clean`d).