### PR TITLE
Removes the dependency on docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ Unlike [AWS Systems Manager (AWS SSM) Parameter Store](https://aws.amazon.com/sy
 
 # Setup
 
+This plugins requires AWS CLI version 1.15 or above, as AWS Secrets Manager support is relatively new.
+
 See [AWS Setup](./AWSSETUP.md) for instructions on setting up the provider AWS account, and the build agent permissions.
 
 # Supported Secrets

--- a/lib/shared.bash
+++ b/lib/shared.bash
@@ -4,9 +4,6 @@ function strip_quotes() {
   echo "${1}" | sed "s/^[ \t]*//g;s/[ \t]*$//g;s/[\"']//g"
 }
 
-# AWS SM is only in very recent AWS CLI versions, and isn't on Amazon Linux 2 AMIs (as of July 2018)
-docker pull infrastructureascode/aws-cli
-
 function get_secret_value() {
   local secretId="$1"
   local allowBinary="${2-}"
@@ -15,17 +12,7 @@ function get_secret_value() {
   # the secret is declared local before using it, per http://mywiki.wooledge.org/BashPitfalls#local_varname.3D.24.28command.29
   local secrets;
   echo -e "\033[31m" >&2
-  secrets=$(docker run \
-    --rm \
-    -v ~/.aws:/root/.aws \
-    -e 'AWS_ACCESS_KEY_ID' \
-    -e 'AWS_SECRET_ACCESS_KEY' \
-    -e 'AWS_DEFAULT_REGION' \
-    -e 'AWS_REGION' \
-    -e 'AWS_SECURITY_TOKEN' \
-    -e 'AWS_SESSION_TOKEN' \
-    infrastructureascode/aws-cli \
-    aws secretsmanager get-secret-value \
+  secrets=$(aws secretsmanager get-secret-value \
       --secret-id "${secretId}" \
       --version-stage AWSCURRENT \
       --output json \


### PR DESCRIPTION
Now AWS CLI 1.15+ is relatively wide-spread, this removes the dependency on docker.