### PR TITLE
Use named :blank: character class in strip_quotes instead of escaped tab

### DIFF
--- a/lib/shared.bash
+++ b/lib/shared.bash
@@ -3,7 +3,7 @@
 BUILDKITE_PLUGIN_AWS_SM_ENDPOINT_URL="${BUILDKITE_PLUGIN_AWS_SM_ENDPOINT_URL:-}"
 
 function strip_quotes() {
-  echo "${1}" | sed "s/^[ \t]*//g;s/[ \t]*$//g;s/[\"']//g"
+  echo "${1}" | sed "s/^[[:blank:]]*//g;s/[[:blank:]]*$//g;s/[\"']//g"
 }
 
 function get_secret_value() {


### PR DESCRIPTION
This allows the shared.bash script to work as intended on macOS as well due to
incompatibility between GNU sed and BSD sed.