### PR TITLE
Add explicit region parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,8 +120,17 @@ steps:
 
 ### For Secrets in Another Region
 
-This plugin supports reading AWS SM secrets from a region that is different from where your agents are running. In this case, use the ARN syntax
-rather than a secret name. The region will be deduced from the secret ARN.
+This plugin supports reading AWS SM secrets from a region that is different from where your agents are running. In this case, you can either use the ARN syntax to deduce the region from the secret ARN or you can set it directly using the `region` parameter.
+
+```yml
+steps:
+  - commands: 'echo \$SECRET_FROM_OTHER_REGION'
+    plugins:
+      - seek-oss/aws-sm#v2.2.1:
+          region: us-east-1
+          env:
+            SECRET_FROM_OTHER_REGION: my-secret-id
+```
 
 ### For use with VPC Endpoints
 

--- a/lib/shared.bash
+++ b/lib/shared.bash
@@ -18,6 +18,10 @@ function get_secret_value() {
     regionFlag="--region ${BASH_REMATCH[1]}"
   fi
 
+  if [[ -n "$BUILDKITE_PLUGIN_AWS_SM_REGION" ]] ; then
+    regionFlag="--region $BUILDKITE_PLUGIN_AWS_SM_REGION"
+  fi
+
   if [[ -n "$BUILDKITE_PLUGIN_AWS_SM_ENDPOINT_URL" ]] ; then
     endpointUrlFlag="--endpoint-url $BUILDKITE_PLUGIN_AWS_SM_ENDPOINT_URL"
   fi


### PR DESCRIPTION
There are cases where you want to change the aws region without having to set the full secret ARN. With this, one can use the friendly secret name and set the region explicitly. This is particularly helpful if you have the same secret-id across multiple regions and don't want to hardcode all ARNs