### PR TITLE
Support export-name property to set case-sensitive variable names

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,21 @@ steps:
               secret-id: "my-other-secret-file-id"
 ```
 
+Note that environment variable names passed as keys to the `env` block are converted to UPPER_CASE. If you need to set
+a lower-cased environment variable name you can pass the `export-name` property:
+
+```yaml
+steps:
+  - commands: 'echo \$someSecret'
+    plugins:
+      - seek-oss/aws-sm#v2.3.1:
+          env:
+            some_secret:  # <- this is ignored
+              export-name: someSecret
+              secret-id: my-secret-id
+```
+
+
 ### For Secrets in JSON
 
 For Secrets in JSON (e.g. you're using AWS SMs key=value support), a `jq`-compatible json-key can be specified:

--- a/hooks/environment
+++ b/hooks/environment
@@ -46,16 +46,30 @@ while IFS='=' read -r name _ ; do
   if [[ $name =~ ^(BUILDKITE_PLUGIN_AWS_SM_ENV_) ]] ; then
     # Special nested value (rather than just a secret id)
     if [[ $name =~ (_SECRET_ID)$ ]] ; then
-      # get the export name from the key, e.g.
+      # get the export name from an explicit export-name key, e.g.
       # env:
-      #   KEY_NAME:
+      #   unused:
       #     secret-id: 'my-secret-id'
-      export_name=$(echo "${name}" | sed 's/^BUILDKITE_PLUGIN_AWS_SM_ENV_//' | sed 's/_SECRET_ID$//')
+      #     export-name: 'SOME_mixed_CASE_env_Var'
+      export_name_var=$(echo "${name}" | sed 's/_SECRET_ID$/_EXPORT_NAME/')
+      export_name="${!export_name_var:-}"
+
+      if [[ -z "$export_name" ]]; then
+        # get the export name from the parent key, e.g.
+        # env:
+        #   KEY_NAME:
+        #     secret-id: 'my-secret-id'
+        export_name=$(echo "${name}" | sed 's/^BUILDKITE_PLUGIN_AWS_SM_ENV_//' | sed 's/_SECRET_ID$//')
+      fi
+
       # load the JSON key if we have one
       json_key_var="BUILDKITE_PLUGIN_AWS_SM_ENV_${export_name}_JSON_KEY"
       json_key="${!json_key_var:-}"
     elif [[ $name =~ (_JSON_KEY)$ ]] ; then
       # ignore this, is used for when loading via _SECRET_ID
+      continue
+    elif [[ $name =~ (_EXPORT_NAME)$ ]] ; then
+      # ignore this, is used for when loading with _EXPORT_NAME
       continue
     else
       # Handle plain key=value, e.g

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -73,6 +73,21 @@ function aws() {
   unset BUILDKITE_PLUGIN_AWS_SM_ENV_TARGET2_SECRET_ID
 }
 
+@test "Fetches values from AWS SM into env with explicit secret-id and export-name" {
+  export BUILDKITE_PLUGIN_AWS_SM_ENV_TARGET1_SECRET_ID="${SECRET_ID1}"
+  export BUILDKITE_PLUGIN_AWS_SM_ENV_TARGET1_EXPORT_NAME="Target1"
+
+  export -f aws
+
+  run "${environment_hook}"
+
+  assert_success
+  assert_output --partial "Reading ${SECRET_ID1} from AWS SM into environment variable Target1"
+
+  unset BUILDKITE_PLUGIN_AWS_SM_ENV_TARGET1_SECRET_ID
+  unset BUILDKITE_PLUGIN_AWS_SM_ENV_TARGET1_EXPORT_NAME
+}
+
 @test "Fetches values from AWS SM into with env with from JSON key" {
   export BUILDKITE_PLUGIN_AWS_SM_ENV_TARGET1="${SECRET_ID1}"
   export BUILDKITE_PLUGIN_AWS_SM_ENV_TARGET2_SECRET_ID="'${SECRET_ID2}'"


### PR DESCRIPTION
This provides a simple fix for #20 - that the plugin can't set lower-case or mixed-case environment variables using the `env` configuration (it can with JSON).

Specifically, this PR adds an optional way to specify an export name directly *as a value*, rather than a property key (because those have their case munged to UPPER_CASE when placed in `BUILDKITE_PLUGIN_*`).

This new supported config type looks like this:

```yaml
steps:
  - commands: 'echo \$someSecret'
    plugins:
      - seek-oss/aws-sm#v2.4.0:
          env:
            foo:
              export-name: someSecret
              secret-id: my-secret-id
            bar:
              export-name: TF_VAR_some_other_secret
              secret-id: another-secret-id
```

---

Closes #20.