### PR TITLE
feat: add basic profile support

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,21 @@ steps:
             SECRET_FROM_OTHER_REGION: my-secret-id
 ```
 
+### For Secrets available to another AWS Profile
+
+This plugin by default uses your current global AWS profile where your agent is running.
+To use another profile for _all the secrets_ you can set it directly with the `profile` parameter.
+
+```yml
+steps:
+  - commands: 'echo \$SECRET_FROM_OTHER_REGION'
+    plugins:
+      - seek-oss/aws-sm#v2.3.1:
+          profile: profile-name
+          env:
+            SECRET_FROM_OTHER_PROFILE: my-secret-id
+```
+
 ### For use with VPC Endpoints
 
 You may want to specify a custom `endpoint-url` if you are using a [VPC endpoint](https://docs.aws.amazon.com/vpc/latest/userguide/vpc-endpoints.html)

--- a/lib/shared.bash
+++ b/lib/shared.bash
@@ -2,6 +2,7 @@
 
 BUILDKITE_PLUGIN_AWS_SM_ENDPOINT_URL="${BUILDKITE_PLUGIN_AWS_SM_ENDPOINT_URL:-}"
 BUILDKITE_PLUGIN_AWS_SM_REGION="${BUILDKITE_PLUGIN_AWS_SM_REGION:-}"
+BUILDKITE_PLUGIN_AWS_SM_PROFILE="${BUILDKITE_PLUGIN_AWS_SM_PROFILE:-${AWS_PROFILE:-default}}"
 
 function strip_quotes() {
   echo "${1}" | sed "s/^[[:blank:]]*//g;s/[[:blank:]]*$//g;s/[\"']//g"
@@ -36,6 +37,7 @@ function get_secret_value() {
       --version-stage AWSCURRENT \
       $regionFlag \
       $endpointUrlFlag \
+      --profile $BUILDKITE_PLUGIN_AWS_SM_PROFILE \
       --output json \
       --query '{SecretString: SecretString, SecretBinary: SecretBinary}')
 


### PR DESCRIPTION
## Summary

Basic support for AWS profiles as per #17 

## Example

```
steps:
  - commands: 'echo \$SECRET_FROM_OTHER_REGION'
    plugins:
      - seek-oss/aws-sm#v2.3.1:
          profile: profile-name
          env:
            SECRET_FROM_OTHER_PROFILE: my-secret-id
```

## Limitations

This Pull Request does not support separate profiles per secret. Due to how env secrets are loaded this would require a much larger and therefore riskier refactor.

Closes #17 