### PR TITLE
Don't print contents of secret values with '\n' characters.

### DIFF
--- a/hooks/environment
+++ b/hooks/environment
@@ -36,7 +36,7 @@ load_all_secrets_into_env() {
   for s in $(jq "${json_key}" <<< "${secret_value}" | jq 'to_entries[] | (.key | sub("[^A-Za-z0-9_]"; "_"; "g")) + "=" + .value'); do
     # convert JSON strings back into raw, e.g \n -> becomes a newline
     s="$(jq -r '.' <<< "${s}")"
-    echo "Setting environment variable $(sed s/=.*//g <<< "$s")"
+    echo "Setting environment variable $(sed s/=.*//g <<< "$(head -n 1 <<< "$s")")"
     export "$s"
   done
 }

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -218,7 +218,6 @@ function aws() {
   unset BUILDKITE_PLUGIN_AWS_SM_JSON_TO_ENV_1_SECRET_ID
 }
 
-
 @test "Fetches all environment variables from JSON with JSON key, avoid logging secrets that contain newlines" {
   export BUILDKITE_PLUGIN_AWS_SM_JSON_TO_ENV_SECRET_ID="${SECRET_ID10}"
   export BUILDKITE_PLUGIN_AWS_SM_JSON_TO_ENV_JSON_KEY="${JSON_KEY10}"

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -1,6 +1,6 @@
 #!/usr/bin/env bats
 
-load "$BATS_PATH/load.bash"
+load "${BATS_PLUGIN_PATH}/load.bash"
 
 environment_hook="$PWD/hooks/environment"
 post_checkout_hook="$PWD/hooks/post-checkout"


### PR DESCRIPTION
We found that one of our secrets was showing immediately in the logs. :( 

The secret is a private key. It is a JSON value that contains `\n` in the string. 
 
This tweak means that the command that sed processes is limited to the first line of the 'raw' string. 

Problematic output:
<img width="725" alt="Screenshot 2023-12-19 at 11 17 43" src="https://github.com/seek-oss/aws-sm-buildkite-plugin/assets/48658802/165b6c5a-399b-4d51-903b-bacf8e1e6f59">
