### PR TITLE
collapse buildkite log group by default

### DIFF
--- a/hooks/environment
+++ b/hooks/environment
@@ -7,7 +7,7 @@ DIR="$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)"
 # shellcheck source=lib/shared.bash
 . "$DIR/../lib/shared.bash"
 
-echo "--- :aws::key: Reading secrets from AWS SM"
+echo "~~~ :aws::key: Reading secrets from AWS SM"
 
 load_secret_into_env() {
   local export_name="$1"

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -228,7 +228,7 @@ function aws() {
 
   assert_success
   expected_output=$(printf '%s\n%s\n[31m\n[0m\n%s\n%s\n%s\n' \
-    "--- :aws::key: Reading secrets from AWS SM" \
+    "~~~ :aws::key: Reading secrets from AWS SM" \
     "Reading all environment variables from ${SECRET_ID10} in AWS SM" \
     "Setting environment variable BEFORE" \
     "Setting environment variable MULTILINE" \


### PR DESCRIPTION
fixes: #29

collapses buildkite log group by default according to docs: https://buildkite.com/docs/pipelines/managing-log-output