### PR TITLE
Automatically redact secrets using buildkite-agent redactor add

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,22 @@ steps:
             MY_SECRET: my-secret-id
 ```
 
+### Secret Redaction
+
+By default, this plugin automatically registers all loaded secrets with Buildkite's secret redactor to prevent accidental exposure in build logs. This ensures that if secrets are printed later in your build commands, they will be automatically redacted.
+
+You can disable this behavior by setting `redact-secrets: false`:
+
+```yml
+steps:
+  - commands: 'echo \$MY_SECRET'
+    plugins:
+      - seek-oss/aws-sm#v2.3.3:
+          redact-secrets: false
+          env:
+            MY_SECRET: my-secret-id
+```
+
 ### Using Secrets in Another Plugin
 
 Per the examples above, the preferred `plugin` YAML syntax is to use an array of plugins over the object-key syntax, as this ensures consistent ordering between plugins.

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ steps:
 
 ### Secret Redaction
 
-By default, this plugin automatically registers all loaded secrets with Buildkite's secret redactor to prevent accidental exposure in build logs. This ensures that if secrets are printed later in your build commands, they will be automatically redacted.
+By default, this plugin automatically registers all loaded secrets with [Buildkite's secret redactor](https://buildkite.com/docs/agent/v3/cli/reference/redactor) to prevent accidental exposure in build logs. This ensures that if secrets are printed later in your build commands, they will be automatically redacted.
 
 You can disable this behavior by setting `redact-secrets: false`:
 

--- a/hooks/environment
+++ b/hooks/environment
@@ -17,9 +17,12 @@ load_secret_into_env() {
   echo "Reading ${secret_id} from AWS SM into environment variable ${export_name}"
   secret_value="$(get_secret_value "${secret_id}")"
   # parse JSON key if we have one
-  if [[ -n "${json_key}" ]] ; then
+  if [[ -n "${json_key}" ]]; then
+    register_secret_with_redactor "${secret_value}" "true"
     echo "Extracting JSON value at '${json_key}' from secret"
     secret_value="$(jq -r "${json_key}" <<< "${secret_value}")"
+  else
+    register_secret_with_redactor "${secret_value}" "false"
   fi
   export "${export_name}=${secret_value}"
 }
@@ -30,6 +33,8 @@ load_all_secrets_into_env() {
   local secret_value
   echo "Reading all environment variables from ${secret_id} in AWS SM"
   secret_value="$(get_secret_value "${secret_id}")"
+  # Register full JSON secret to protect all values
+  register_secret_with_redactor "${secret_value}" "true"
   local IFS=$'\n'
   # the variable is sanitised in jq to avoid problems with keys containing =
   # raw output isn't used here to avoid messing the secrets that contain spaces

--- a/hooks/post-checkout
+++ b/hooks/post-checkout
@@ -16,5 +16,6 @@ while IFS='=' read -r name _ ; do
     path=$(strip_quotes "${!pathVar}")
     echo "Reading ${secretId} from AWS SM into file ${path}"
     get_secret_value "${secretId}" 'allow-binary' > "${path}"
+    register_file_with_redactor "${path}"
   fi
 done < <(env | sort)

--- a/lib/shared.bash
+++ b/lib/shared.bash
@@ -60,3 +60,32 @@ function get_secret_value() {
   # assume it's a string
   echo "${secrets}" | jq -r '.SecretString'
 }
+
+function is_redaction_enabled() {
+  [[ "${BUILDKITE_PLUGIN_AWS_SM_REDACT_SECRETS:-true}" == "true" ]]
+}
+
+function register_secret_with_redactor() {
+  local secret_value="$1"
+  local is_json="${2:-}"
+
+  if ! is_redaction_enabled || [[ -z "${secret_value}" ]]; then
+    return 0
+  fi
+
+  if [[ "${is_json}" == "true" ]]; then
+    echo "${secret_value}" | buildkite-agent redactor add --format json
+  else
+    echo "${secret_value}" | buildkite-agent redactor add
+  fi
+}
+
+function register_file_with_redactor() {
+  local file_path="$1"
+
+  if ! is_redaction_enabled || [[ ! -f "${file_path}" ]] || [[ ! -s "${file_path}" ]]; then
+    return 0
+  fi
+
+  buildkite-agent redactor add "${file_path}"
+}

--- a/plugin.yml
+++ b/plugin.yml
@@ -16,4 +16,6 @@ configuration:
       type: array
     region:
       type: string
+    redact-secrets:
+      type: boolean
   required: []

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -238,3 +238,84 @@ function aws() {
   unset BUILDKITE_PLUGIN_AWS_SM_JSON_TO_ENV_SECRET_ID
   unset BUILDKITE_PLUGIN_AWS_SM_JSON_TO_ENV_JSON_KEY
 }
+
+@test "Registers secrets with redactor by default" {
+  export BUILDKITE_PLUGIN_AWS_SM_ENV_TARGET1="${SECRET_ID1}"
+  export BUILDKITE_PLUGIN_AWS_SM_ENV_TARGET2_SECRET_ID="${SECRET_ID2}"
+  export BUILDKITE_PLUGIN_AWS_SM_ENV_TARGET2_JSON_KEY=".nested"
+
+  # Stub buildkite-agent to track calls
+  stub buildkite-agent \
+    "redactor add : echo 'redactor add called'" \
+    "redactor add --format json : echo 'redactor add --format json called'"
+
+  export -f aws
+
+  run "${environment_hook}"
+
+  assert_success
+  # Should be called for both secrets (plain text and JSON format)
+  unstub buildkite-agent
+
+  unset BUILDKITE_PLUGIN_AWS_SM_ENV_TARGET1
+  unset BUILDKITE_PLUGIN_AWS_SM_ENV_TARGET2_SECRET_ID
+  unset BUILDKITE_PLUGIN_AWS_SM_ENV_TARGET2_JSON_KEY
+}
+
+@test "Registers JSON secrets with JSON format" {
+  export BUILDKITE_PLUGIN_AWS_SM_JSON_TO_ENV_SECRET_ID="${SECRET_ID6}"
+
+  # Stub buildkite-agent to verify JSON format is used
+  stub buildkite-agent "redactor add --format json : echo 'redactor add --format json called'"
+
+  export -f aws
+
+  run "${environment_hook}"
+
+  assert_success
+  # Should be called with --format json
+  unstub buildkite-agent
+
+  unset BUILDKITE_PLUGIN_AWS_SM_JSON_TO_ENV_SECRET_ID
+}
+
+@test "Registers file secrets with redactor" {
+  local test_out_dir="/tmp/aws-sm-redactor"
+  mkdir -p "${test_out_dir}"
+  local path1="${test_out_dir}/path1"
+  export BUILDKITE_PLUGIN_AWS_SM_FILE_0_PATH="${path1}"
+  export BUILDKITE_PLUGIN_AWS_SM_FILE_0_SECRET_ID="${SECRET_ID1}"
+
+  # Stub buildkite-agent to verify file path is passed
+  stub buildkite-agent "redactor add ${path1} : echo 'redactor add called with file'"
+
+  export -f aws
+
+  run "${post_checkout_hook}"
+
+  assert_success
+  # Should be called with file path
+  unstub buildkite-agent
+
+  unset BUILDKITE_PLUGIN_AWS_SM_FILE_0_PATH
+  unset BUILDKITE_PLUGIN_AWS_SM_FILE_0_SECRET_ID
+  rm -rf "${test_out_dir}"
+}
+
+@test "Respects redact-secrets: false option" {
+  export BUILDKITE_PLUGIN_AWS_SM_ENV_TARGET1="${SECRET_ID1}"
+  export BUILDKITE_PLUGIN_AWS_SM_REDACT_SECRETS="false"
+
+  # Don't stub buildkite-agent - if it's called, the test should fail
+  # Since redaction is disabled, buildkite-agent should never be called
+
+  export -f aws
+
+  run "${environment_hook}"
+
+  assert_success
+  # buildkite-agent should not be called when redaction is disabled
+
+  unset BUILDKITE_PLUGIN_AWS_SM_ENV_TARGET1
+  unset BUILDKITE_PLUGIN_AWS_SM_REDACT_SECRETS
+}


### PR DESCRIPTION
- Prevent accidentally printing secrets in Buildkite logs
- Allow disabling with a new redact-secrets config option